### PR TITLE
Update requirements with tensorflow_probability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ optax
 rich
 ruamel.yaml<0.18.0 # safe_dump is deprecated (and removed) from 0.18.0 and above
 tensorflow-cpu
-tensorflow_probability
+tensorflow_probability==0.21.0
 
 # wandb
 # moviepy # Needed for gif/video saving to wandb

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ optax
 rich
 ruamel.yaml<0.18.0 # safe_dump is deprecated (and removed) from 0.18.0 and above
 tensorflow-cpu
-tensorflow_probability==0.21.0
+tensorflow_probability<=0.21.0 # After this error: https://stackoverflow.com/questions/77221932/jax-prng-key-error-with-tfp-normal-distribution
 
 # wandb
 # moviepy # Needed for gif/video saving to wandb


### PR DESCRIPTION
I received the following error when running `CUDA_VISIBLE_DEVICES=0 python tests/dreamertest.py` from [here](https://github.com/Kinds-of-Intelligence-CFI/animal-ai-dreamerv3): `AttributeError: module 'jax.dtypes' has no attribute 'prng_key'`. This looks to be an error with `tensorflow_probability` (see discussion [here](https://stackoverflow.com/questions/77221932/jax-prng-key-error-with-tfp-normal-distribution)), so this is a very small update to the requirements setting the package version to 0.21.0.

The script now works with this change.